### PR TITLE
Added new annotation colour as a test

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -23,6 +23,10 @@
           "value": "#15a045",
           "type": "color",
           "description": "Not part of design system, only used for annotating page templates for designers"
+        },
+        "test": {
+          "value": "#fb06d1",
+          "type": "color"
         }
       },
       "grey": {

--- a/tokens/tokens-figma/core.json
+++ b/tokens/tokens-figma/core.json
@@ -22,6 +22,10 @@
         "value": "#15a045",
         "type": "color",
         "description": "Not part of design system, only used for annotating page templates for designers"
+      },
+      "test": {
+        "value": "#fb06d1",
+        "type": "color"
       }
     },
     "grey": {


### PR DESCRIPTION
New colour added to annotations in design system as part of token studio test. This can be deleted at end of firebreak week (27/9/24)