### PR TITLE
Remove wide desktop and updates for MVP

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1310,10 +1310,18 @@
       }
     },
     "opacity": {
+      "25": {
+        "value": "0.25",
+        "type": "opacity"
+      },
       "50": {
         "value": "0.5",
         "type": "opacity",
         "description": "Used as a background overlay to mute the background when another layer (e.g. modal, drawer) is opened."
+      },
+      "75": {
+        "value": "0.75",
+        "type": "opacity"
       },
       "100": {
         "value": "1",

--- a/tokens.json
+++ b/tokens.json
@@ -904,7 +904,7 @@
           "description": "Buttons, navigation, and other UI components."
         },
         "md": {
-          "value": "120%",
+          "value": "130%",
           "type": "lineHeights",
           "description": "Body text and captions."
         },

--- a/tokens.json
+++ b/tokens.json
@@ -853,7 +853,7 @@
           "type": "fontFamilies"
         },
         "brand": {
-          "value": "Wellcome, “Wellcome-Bold”, sans-serif",
+          "value": "Wellcome, sans-serif",
           "type": "fontFamilies"
         },
         "sans": {
@@ -904,18 +904,14 @@
           "description": "Buttons, navigation, and other UI components."
         },
         "md": {
-          "value": "130%",
+          "value": "120%",
           "type": "lineHeights",
           "description": "Body text and captions."
         },
         "lg": {
-          "value": "160%",
+          "value": "150%",
           "type": "lineHeights",
           "description": "Display, heading and long form body text."
-        },
-        "xl": {
-          "value": "180%",
-          "type": "lineHeights"
         }
       },
       "text-case": {
@@ -929,53 +925,6 @@
         }
       },
       "size": {
-        "bp-sm": {
-          "f6": {
-            "value": "39.84",
-            "type": "fontSizes",
-            "description": "Tokens value for figma"
-          },
-          "f5": {
-            "value": "34.88",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          },
-          "f3": {
-            "value": "26.36",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          },
-          "f2": {
-            "value": "22.52",
-            "type": "fontSizes",
-            "description": "Token value for figma\n"
-          },
-          "f1": {
-            "value": "19.68",
-            "type": "fontSizes",
-            "description": "Token value for figma \n"
-          },
-          "f0": {
-            "value": "17.12",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          },
-          "f-1": {
-            "value": "14.84",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          },
-          "f-2": {
-            "value": "13.28",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          },
-          "f-3": {
-            "value": "11.28",
-            "type": "fontSizes",
-            "description": "Token value for figma"
-          }
-        },
         "bp-xs": {
           "f6": {
             "value": "32",
@@ -1019,6 +968,53 @@
           },
           "f-3": {
             "value": "11",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          }
+        },
+        "bp-sm": {
+          "f6": {
+            "value": "39.84",
+            "type": "fontSizes",
+            "description": "Tokens value for figma"
+          },
+          "f5": {
+            "value": "34.88",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          },
+          "f3": {
+            "value": "26.36",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          },
+          "f2": {
+            "value": "22.52",
+            "type": "fontSizes",
+            "description": "Token value for figma\n"
+          },
+          "f1": {
+            "value": "19.68",
+            "type": "fontSizes",
+            "description": "Token value for figma \n"
+          },
+          "f0": {
+            "value": "17.12",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          },
+          "f-1": {
+            "value": "14.84",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          },
+          "f-2": {
+            "value": "13.28",
+            "type": "fontSizes",
+            "description": "Token value for figma"
+          },
+          "f-3": {
+            "value": "11.28",
             "type": "fontSizes",
             "description": "Token value for figma"
           }
@@ -1704,75 +1700,6 @@
       }
     }
   },
-  "BREAKPOINTS/Wide desktop": {
-    "font": {
-      "size": {
-        "f6": {
-          "value": "{font.size.bp-xl.f6}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f5": {
-          "value": "{font.size.bp-xl.f5}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f3": {
-          "value": "{font.size.bp-xl.f3}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f2": {
-          "value": "{font.size.bp-xl.f2}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f1": {
-          "value": "{font.size.bp-xl.f1}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f0": {
-          "value": "{font.size.bp-xl.f0}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-1": {
-          "value": "{font.size.bp-xl.f-1}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-2": {
-          "value": "{font.size.bp-xl.f-2}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-3": {
-          "value": "{font.size.bp-xl.f-3}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        }
-      }
-    },
-    "grid": {
-      "breakpoint": {
-        "value": "{grid.breakpoint.xl}",
-        "type": "sizing"
-      },
-      "columns": {
-        "value": "{grid.columns.lg}",
-        "type": "sizing"
-      },
-      "margin": {
-        "value": "0",
-        "type": "sizing"
-      },
-      "gutter": {
-        "value": "0",
-        "type": "sizing"
-      }
-    }
-  },
   "$themes": [
     {
       "id": "6065494081d349c78947746e7f2cbe21b78972db",
@@ -1885,10 +1812,10 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "00 Core": "source",
-        "01 Semantic": "source",
-        "BREAKPOINTS/Wide desktop": "enabled"
+        "01 Semantic": "source"
       },
-      "group": "02 Responsive"
+      "group": "02 Responsive",
+      "$figmaVariableReferences": {}
     }
   ],
   "$metadata": {
@@ -1897,8 +1824,7 @@
       "01 Semantic",
       "BREAKPOINTS/Desktop",
       "BREAKPOINTS/Tablet",
-      "BREAKPOINTS/Mobile",
-      "BREAKPOINTS/Wide desktop"
+      "BREAKPOINTS/Mobile"
     ]
   }
 }


### PR DESCRIPTION
## What does this change?

- Removed wide desktop (agreed to remove for MVP)
- Updated font.family.brand to fit with the naming of the new Wellcome font
- Fixed ordering of some elements
- Removed font.line-height.lg (180%) (not used or documented so assumed it's not needed)
