### PR TITLE
Removed wide desktop 'set' in Tokens studio

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1704,75 +1704,6 @@
       }
     }
   },
-  "BREAKPOINTS/Wide desktop": {
-    "font": {
-      "size": {
-        "f6": {
-          "value": "{font.size.bp-xl.f6}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f5": {
-          "value": "{font.size.bp-xl.f5}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f3": {
-          "value": "{font.size.bp-xl.f3}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f2": {
-          "value": "{font.size.bp-xl.f2}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f1": {
-          "value": "{font.size.bp-xl.f1}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f0": {
-          "value": "{font.size.bp-xl.f0}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-1": {
-          "value": "{font.size.bp-xl.f-1}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-2": {
-          "value": "{font.size.bp-xl.f-2}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        },
-        "f-3": {
-          "value": "{font.size.bp-xl.f-3}",
-          "type": "fontSizes",
-          "description": "Token value for figma"
-        }
-      }
-    },
-    "grid": {
-      "breakpoint": {
-        "value": "{grid.breakpoint.xl}",
-        "type": "sizing"
-      },
-      "columns": {
-        "value": "{grid.columns.lg}",
-        "type": "sizing"
-      },
-      "margin": {
-        "value": "0",
-        "type": "sizing"
-      },
-      "gutter": {
-        "value": "0",
-        "type": "sizing"
-      }
-    }
-  },
   "$themes": [
     {
       "id": "6065494081d349c78947746e7f2cbe21b78972db",
@@ -1885,8 +1816,7 @@
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
         "00 Core": "source",
-        "01 Semantic": "source",
-        "BREAKPOINTS/Wide desktop": "enabled"
+        "01 Semantic": "source"
       },
       "group": "02 Responsive"
     }
@@ -1897,8 +1827,7 @@
       "01 Semantic",
       "BREAKPOINTS/Desktop",
       "BREAKPOINTS/Tablet",
-      "BREAKPOINTS/Mobile",
-      "BREAKPOINTS/Wide desktop"
+      "BREAKPOINTS/Mobile"
     ]
   }
 }


### PR DESCRIPTION
## What does this change?
Wide desktop was still appearing in Tokens Studio as a set in the left nav so I've tried removing it again
<img width="163" alt="image" src="https://github.com/user-attachments/assets/c1f54ee5-b0e1-456e-a545-f04ba4f51315" />
