### PR TITLE
Task/add and update colours

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1373,57 +1373,57 @@
       }
     },
     "information": {
-      "10": {
+      "light": {
         "value": "{color.UI.blue.10}",
         "type": "color"
       },
-      "40": {
+      "mid": {
         "value": "{color.UI.blue.40}",
         "type": "color"
       },
-      "60": {
+      "dark": {
         "value": "{color.UI.blue.60}",
         "type": "color"
       }
     },
     "success": {
-      "10": {
+      "light": {
         "value": "{color.UI.green.10}",
         "type": "color"
       },
-      "40": {
+      "mid": {
         "value": "{color.UI.green.40}",
         "type": "color"
       },
-      "60": {
+      "dark": {
         "value": "{color.UI.green.60}",
         "type": "color"
       }
     },
     "warning": {
-      "10": {
+      "light": {
         "value": "{color.UI.yellow.10}",
         "type": "color"
       },
-      "40": {
+      "mid": {
         "value": "{color.UI.yellow.40}",
         "type": "color"
       },
-      "60": {
+      "dark": {
         "value": "{color.UI.yellow.60}",
         "type": "color"
       }
     },
     "error": {
-      "10": {
+      "light": {
         "value": "{color.UI.red.10}",
         "type": "color"
       },
-      "40": {
+      "mid": {
         "value": "{color.UI.red.40}",
         "type": "color"
       },
-      "60": {
+      "dark": {
         "value": "{color.UI.red.60}",
         "type": "color"
       }

--- a/tokens.json
+++ b/tokens.json
@@ -338,340 +338,302 @@
           "description": "Not part of design system, only used for annotating page templates for designers"
         }
       },
-      "grey": {
+      "neutral": {
         "10": {
-          "value": "#e6e6e6",
+          "value": "#F5F6EE",
           "type": "color"
         },
         "20": {
-          "value": "#cccccc",
+          "value": "#D2D6D0",
           "type": "color"
         },
         "30": {
-          "value": "#b3b3b3",
+          "value": "#AFB5B1",
           "type": "color"
         },
         "40": {
-          "value": "#999999",
+          "value": "#8C9593",
           "type": "color"
         },
         "50": {
-          "value": "#878787",
+          "value": "#657373",
           "type": "color"
         },
         "60": {
-          "value": "#767676",
+          "value": "#445254",
           "type": "color"
         },
         "70": {
-          "value": "#5c5c5c",
-          "type": "color"
-        },
-        "80": {
-          "value": "#292929",
-          "type": "color"
-        },
-        "90": {
-          "value": "#000000",
-          "type": "color"
-        },
-        "05": {
-          "value": "#f2f2f2",
+          "value": "#223438",
           "type": "color"
         }
       },
-      "amber": {
+      "pink": {
         "10": {
-          "value": "#fff4d1",
+          "value": "#FFF2FA",
           "type": "color"
         },
         "20": {
-          "value": "#ffe699",
+          "value": "#FFC9EA",
           "type": "color"
         },
         "30": {
-          "value": "#fec200",
+          "value": "#FFA5DC",
           "type": "color"
         },
         "40": {
-          "value": "#e7ae04",
+          "value": "#F261BA",
           "type": "color"
         },
         "50": {
-          "value": "#c29207",
+          "value": "#CB298D",
           "type": "color"
         },
         "60": {
-          "value": "#946f00",
+          "value": "#860956",
           "type": "color"
         },
         "70": {
-          "value": "#705400",
-          "type": "color"
-        },
-        "80": {
-          "value": "#4d3900",
-          "type": "color"
-        },
-        "90": {
-          "value": "#382a00",
-          "type": "color"
-        },
-        "05": {
-          "value": "#fffbf0",
-          "type": "color"
-        }
-      },
-      "blue": {
-        "10": {
-          "value": "#dbeaff",
-          "type": "color"
-        },
-        "20": {
-          "value": "#b3d2ff",
-          "type": "color"
-        },
-        "30": {
-          "value": "#80b5ff",
-          "type": "color"
-        },
-        "40": {
-          "value": "#4d97ff",
-          "type": "color"
-        },
-        "50": {
-          "value": "#1672f3",
-          "type": "color"
-        },
-        "60": {
-          "value": "#0055cc",
-          "type": "color"
-        },
-        "70": {
-          "value": "#004099",
-          "type": "color"
-        },
-        "80": {
-          "value": "#003170",
-          "type": "color"
-        },
-        "90": {
-          "value": "#002e45",
-          "type": "color"
-        },
-        "05": {
-          "value": "#f0f6ff",
-          "type": "color"
-        }
-      },
-      "cyan": {
-        "10": {
-          "value": "#dcf4f9",
-          "type": "color"
-        },
-        "20": {
-          "value": "#beebf4",
-          "type": "color"
-        },
-        "30": {
-          "value": "#9dd8e7",
-          "type": "color"
-        },
-        "40": {
-          "value": "#71bdd0",
-          "type": "color"
-        },
-        "50": {
-          "value": "#009bb2",
-          "type": "color"
-        },
-        "60": {
-          "value": "#006272",
-          "type": "color"
-        },
-        "70": {
-          "value": "#005361",
-          "type": "color"
-        },
-        "80": {
-          "value": "#00424d",
-          "type": "color"
-        },
-        "90": {
-          "value": "#002c33",
-          "type": "color"
-        },
-        "05": {
-          "value": "#f1fcfd",
-          "type": "color"
-        }
-      },
-      "green": {
-        "10": {
-          "value": "#f0f9e7",
-          "type": "color"
-        },
-        "20": {
-          "value": "#e6f1d3",
-          "type": "color"
-        },
-        "30": {
-          "value": "#b6d99c",
-          "type": "color"
-        },
-        "40": {
-          "value": "#8cc059",
-          "type": "color"
-        },
-        "50": {
-          "value": "#6ba136",
-          "type": "color"
-        },
-        "60": {
-          "value": "#4c8026",
-          "type": "color"
-        },
-        "70": {
-          "value": "#236126",
-          "type": "color"
-        },
-        "80": {
-          "value": "#2a512c",
-          "type": "color"
-        },
-        "90": {
-          "value": "#133800",
-          "type": "color"
-        },
-        "05": {
-          "value": "#f7fcf2",
-          "type": "color"
-        }
-      },
-      "orange": {
-        "10": {
-          "value": "#ffeddb",
-          "type": "color"
-        },
-        "20": {
-          "value": "#ffd9b2",
-          "type": "color"
-        },
-        "30": {
-          "value": "#ffbf80",
-          "type": "color"
-        },
-        "40": {
-          "value": "#ffa64d",
-          "type": "color"
-        },
-        "50": {
-          "value": "#f07f0a",
-          "type": "color"
-        },
-        "60": {
-          "value": "#b45c04",
-          "type": "color"
-        },
-        "70": {
-          "value": "#8a471e",
-          "type": "color"
-        },
-        "80": {
-          "value": "#572b00",
-          "type": "color"
-        },
-        "90": {
-          "value": "#331e0f",
-          "type": "color"
-        },
-        "05": {
-          "value": "#fff7f0",
-          "type": "color"
-        }
-      },
-      "red": {
-        "10": {
-          "value": "#f9cdca",
-          "type": "color"
-        },
-        "20": {
-          "value": "#ed858e",
-          "type": "color"
-        },
-        "30": {
-          "value": "#f2637b",
-          "type": "color"
-        },
-        "40": {
-          "value": "#f04763",
-          "type": "color"
-        },
-        "50": {
-          "value": "#e72343",
-          "type": "color"
-        },
-        "60": {
-          "value": "#e10f2d",
-          "type": "color"
-        },
-        "70": {
-          "value": "#b3001e",
-          "type": "color"
-        },
-        "80": {
-          "value": "#6c131d",
-          "type": "color"
-        },
-        "90": {
-          "value": "#40120d",
-          "type": "color"
-        },
-        "05": {
-          "value": "#fff0f2",
+          "value": "#360021",
           "type": "color"
         }
       },
       "yellow": {
         "10": {
-          "value": "#fffde2",
+          "value": "#FFFEF0",
           "type": "color"
         },
         "20": {
-          "value": "#fff9a6",
+          "value": "#FFFAAE",
           "type": "color"
         },
         "30": {
-          "value": "#fff266",
+          "value": "#FFEE00",
           "type": "color"
         },
         "40": {
-          "value": "#ffea00",
+          "value": "#DBCD00",
           "type": "color"
         },
         "50": {
-          "value": "#b5a70d",
+          "value": "#7A7200",
           "type": "color"
         },
         "60": {
-          "value": "#817818",
+          "value": "#544F00",
           "type": "color"
         },
         "70": {
-          "value": "#706601",
+          "value": "#2E2B00",
+          "type": "color"
+        }
+      },
+      "blue": {
+        "10": {
+          "value": "#EDF6FF",
           "type": "color"
         },
-        "80": {
-          "value": "#574f00",
+        "20": {
+          "value": "#BFDFFF",
           "type": "color"
         },
-        "90": {
-          "value": "#3d3800",
+        "30": {
+          "value": "#8FC7FF",
           "type": "color"
         },
-        "05": {
-          "value": "#fffef0",
+        "40": {
+          "value": "#549FE9",
           "type": "color"
+        },
+        "50": {
+          "value": "#2672BE",
+          "type": "color"
+        },
+        "60": {
+          "value": "#0C4783",
+          "type": "color"
+        },
+        "70": {
+          "value": "#011F3D",
+          "type": "color"
+        }
+      },
+      "indigo": {
+        "10": {
+          "value": "#EDEBFA",
+          "type": "color"
+        },
+        "20": {
+          "value": "#CAC3FA",
+          "type": "color"
+        },
+        "30": {
+          "value": "#A194F4",
+          "type": "color"
+        },
+        "40": {
+          "value": "#6C6ED7",
+          "type": "color"
+        },
+        "50": {
+          "value": "#3B44BA",
+          "type": "color"
+        },
+        "60": {
+          "value": "#242B7D",
+          "type": "color"
+        },
+        "70": {
+          "value": "#14184D",
+          "type": "color"
+        }
+      },
+      "teal": {
+        "10": {
+          "value": "#E9F5F4",
+          "type": "color"
+        },
+        "20": {
+          "value": "#C3D8D7",
+          "type": "color"
+        },
+        "30": {
+          "value": "#8DA8A7",
+          "type": "color"
+        },
+        "40": {
+          "value": "#547876",
+          "type": "color"
+        },
+        "50": {
+          "value": "#2A5250",
+          "type": "color"
+        },
+        "60": {
+          "value": "#153B39",
+          "type": "color"
+        },
+        "70": {
+          "value": "#012927",
+          "type": "color"
+        }
+      },
+      "orange": {
+        "10": {
+          "value": "#FCF4F0",
+          "type": "color"
+        },
+        "20": {
+          "value": "#FFDECD",
+          "type": "color"
+        },
+        "30": {
+          "value": "#FFB691",
+          "type": "color"
+        },
+        "40": {
+          "value": "#F2824A",
+          "type": "color"
+        },
+        "50": {
+          "value": "#A35229",
+          "type": "color"
+        },
+        "60": {
+          "value": "#6B351A",
+          "type": "color"
+        },
+        "70": {
+          "value": "#33190C",
+          "type": "color"
+        }
+      },
+      "green": {
+        "10": {
+          "value": "#F0F5DF",
+          "type": "color"
+        },
+        "20": {
+          "value": "#D9E3B3",
+          "type": "color"
+        },
+        "30": {
+          "value": "#B6C47E",
+          "type": "color"
+        },
+        "40": {
+          "value": "#98A953",
+          "type": "color"
+        },
+        "50": {
+          "value": "#64761F",
+          "type": "color"
+        },
+        "60": {
+          "value": "#46540D",
+          "type": "color"
+        },
+        "70": {
+          "value": "#212900",
+          "type": "color"
+        }
+      },
+      "UI": {
+        "blue": {
+          "10": {
+            "value": "{color.blue.10}",
+            "type": "color"
+          },
+          "40": {
+            "value": "{color.blue.40}",
+            "type": "color"
+          },
+          "60": {
+            "value": "{color.blue.60}",
+            "type": "color"
+          }
+        },
+        "green": {
+          "10": {
+            "value": "#EFFCE3",
+            "type": "color"
+          },
+          "40": {
+            "value": "#81C14B",
+            "type": "color"
+          },
+          "60": {
+            "value": "#417F0D",
+            "type": "color"
+          }
+        },
+        "yellow": {
+          "10": {
+            "value": "{color.yellow.10}",
+            "type": "color"
+          },
+          "40": {
+            "value": "{color.yellow.40}",
+            "type": "color"
+          },
+          "60": {
+            "value": "{color.yellow.60}",
+            "type": "color"
+          }
+        },
+        "red": {
+          "10": {
+            "value": "#FFF0F2",
+            "type": "color"
+          },
+          "40": {
+            "value": "#E72343",
+            "type": "color"
+          },
+          "60": {
+            "value": "#6C131D",
+            "type": "color"
+          }
         }
       }
     },
@@ -1408,6 +1370,62 @@
           "value": "{dimension.999}",
           "type": "borderRadius"
         }
+      }
+    },
+    "information": {
+      "10": {
+        "value": "{color.UI.blue.10}",
+        "type": "color"
+      },
+      "40": {
+        "value": "{color.UI.blue.40}",
+        "type": "color"
+      },
+      "60": {
+        "value": "{color.UI.blue.60}",
+        "type": "color"
+      }
+    },
+    "success": {
+      "10": {
+        "value": "{color.UI.green.10}",
+        "type": "color"
+      },
+      "40": {
+        "value": "{color.UI.green.40}",
+        "type": "color"
+      },
+      "60": {
+        "value": "{color.UI.green.60}",
+        "type": "color"
+      }
+    },
+    "warning": {
+      "10": {
+        "value": "{color.UI.yellow.10}",
+        "type": "color"
+      },
+      "40": {
+        "value": "{color.UI.yellow.40}",
+        "type": "color"
+      },
+      "60": {
+        "value": "{color.UI.yellow.60}",
+        "type": "color"
+      }
+    },
+    "error": {
+      "10": {
+        "value": "{color.UI.red.10}",
+        "type": "color"
+      },
+      "40": {
+        "value": "{color.UI.red.40}",
+        "type": "color"
+      },
+      "60": {
+        "value": "{color.UI.red.60}",
+        "type": "color"
       }
     }
   },


### PR DESCRIPTION
- Legacy Trust design system colours deleted from Tokens Studio
- New core colour tokens added using correct token naming structure
- Semantic tokens added for UI colours

When updating colours in the design system repo the legacy colours should map to the new values as per the [documentation on figma here ](https://www.figma.com/design/4imhRtYO5KCTLKMhW6fJbO/Design-System-2024?node-id=1685-43606&t=iUrWcfrKZrLt43Rs-1)This will ensure no legacy colours remain in the code base and all instances are replaced with a new colour value
