### PR TITLE
Removed annotation colours from WDS

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -317,27 +317,6 @@
         "value": "#000000",
         "type": "color"
       },
-      "annotations": {
-        "purple": {
-          "value": "#6549f5",
-          "type": "color",
-          "description": "Not part of design system, only used for annotating designs"
-        },
-        "purple-light": {
-          "value": "#6549f533",
-          "type": "color"
-        },
-        "green": {
-          "value": "#15a045",
-          "type": "color",
-          "description": "Not part of design system, only used for annotating page templates for designers"
-        },
-        "pink": {
-          "value": "#ea07e4",
-          "type": "color",
-          "description": "Not part of design system, only used for annotating page templates for designers"
-        }
-      },
       "neutral": {
         "10": {
           "value": "#F5F6EE",


### PR DESCRIPTION
Removed annotation colours as agreed in the design system catch-up. 
We'll still have those colours in Figma, but not in the design system 