### PR TITLE
updates readme to reflect release process more accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once a pull request with the necessary changes is merged, the developer:
 3. Set the package version using the npm cli:
 
   ```
-  npm version <major|minor|patch> -m "Released version %s: <brief_description>
+  npm version <major|minor|patch> -m "Released version %s: <brief_description>"
   ```
 
 4. Runs the following command to publish the new version of the package:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,30 @@ const config = {
 
 Once a pull request with the necessary changes is merged, the developer:
 
-1. Updates the "version" in the package.json, using the appropriate semver.
-2. Runs the following command to publish the new version of the package:
+1. Checks out a new branch, the name isn't particularly important, something appropriate such as `git checkout -b task/updates-version` is fine.
+2. Ensure the dependencies are up-to-date, run `npm ci`.
+3. Set the package version using the npm cli:
+
+  ```
+  npm version <major|minor|patch> -m "Released version %s: <brief_description>
+  ```
+
+4. Runs the following command to publish the new version of the package:
 
    ```
    npm publish --access public
    ```
 
-You can now `npm install @wellcometrust/wellcome-design-system@{version|latest}` to use the new version in your project.
+5. Push the branch *and the tags* to the Github repo:
+
+  ```
+  git push -u origin <branch_name> --follow-tags
+  ```
+
+6. Create a pull request against `main`, request a review from other developers
+7. Once approved, merge the pull request into `main`.
+
+You can now `npm install @wellcometrust/wellcome-design-system@{version_number|latest}` to use the new version in your project.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->

Updates the readme.md to more accurately reflect the desired release process. Previously, the readme specified that changes would be made directly to `main`, but we probably don't want to do this. 

We want new npm versions to be created on a new branch and then merged in via pull request.

I've based the process on https://www.notion.so/wellcometrust/How-to-Publish-to-NPM-e48af79273e64224b75b350b8ec926f2.

I haven't included the section on creating a Github release... do people think we should do this? Or is it unnecessary overhead?

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
