### PR TITLE
Replace percentage values for line height

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -77,9 +77,9 @@
 }
 
 :root {
-  --wds-line-height-sm: 100%;
-  --wds-line-height-md: 130%;
-  --wds-line-height-lg: 150%;
+  --wds-line-height-sm: 1;
+  --wds-line-height-md: 1.3;
+  --wds-line-height-lg: 1.5;
 }
 
 :root {


### PR DESCRIPTION
## What does this change?

Percentage values can result in unpredictable results - as described here https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#percentage 

I found when implementing the new line heights for .org, the percentage tokens caused issues - so I suggest we move to simple number values equivalent to percentages...

