### PR TITLE
Composite typography updates

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1271,7 +1271,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.f1}",
+            "fontSize": "{font-size.f1}",
             "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1323,7 +1323,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.f1}",
+            "fontSize": "{font-size.f1}",
             "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1377,7 +1377,7 @@
           "value": {
             "fontFamily": "{font.family.brand}",
             "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.f6}",
+            "fontSize": "{font-size.f6}",
             "lineHeight": "{font.line-height.md}",
             "letterSpacing": "{font.letter-spacing.tight}"
           },
@@ -1411,7 +1411,7 @@
           "value": {
             "fontFamily": "{font.family.mono}",
             "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.f-3}",
+            "fontSize": "{font-size.f-3}",
             "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1433,7 +1433,7 @@
           "value": {
             "fontFamily": "{font.family.mono}",
             "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.f-3}",
+            "fontSize": "{font-size.f-3}",
             "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1448,7 +1448,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f3}",
+              "fontSize": "{font-size.f3}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.spacious}"
             },
@@ -1458,7 +1458,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f2}",
+              "fontSize": "{font-size.f2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.spacious}"
             },
@@ -1468,7 +1468,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f1}",
+              "fontSize": "{font-size.f1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1478,7 +1478,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f0}",
+              "fontSize": "{font-size.f0}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1488,7 +1488,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f-1}",
+              "fontSize": "{font-size.f-1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1498,7 +1498,7 @@
             "value": {
               "fontFamily": "{font.family.sans}",
               "fontWeight": "{font.weight.semibold}",
-              "fontSize": "{font.size.f-2}",
+              "fontSize": "{font-size.f-2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1512,7 +1512,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f3}",
+              "fontSize": "{font-size.f3}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1522,7 +1522,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f2}",
+              "fontSize": "{font-size.f2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1532,7 +1532,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f1}",
+              "fontSize": "{font-size.f1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1542,7 +1542,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f0}",
+              "fontSize": "{font-size.f0}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1552,7 +1552,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f-1}",
+              "fontSize": "{font-size.f-1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1562,7 +1562,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.regular}",
-              "fontSize": "{font.size.f-2}",
+              "fontSize": "{font-size.f-2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.comfortable}"
             },
@@ -1574,7 +1574,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f3}",
+              "fontSize": "{font-size.f3}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1584,7 +1584,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f2}",
+              "fontSize": "{font-size.f2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1594,7 +1594,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f1}",
+              "fontSize": "{font-size.f1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1604,7 +1604,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f0}",
+              "fontSize": "{font-size.f0}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1614,7 +1614,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f-1}",
+              "fontSize": "{font-size.f-1}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1624,7 +1624,7 @@
             "value": {
               "fontFamily": "{font.family.brand}",
               "fontWeight": "{font.weight.bold}",
-              "fontSize": "{font.size.f-2}",
+              "fontSize": "{font-size.f-2}",
               "lineHeight": "{font.line-height.md}",
               "letterSpacing": "{font.letter-spacing.tight}"
             },
@@ -1639,7 +1639,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.f-1}",
+            "fontSize": "{font-size.f-1}",
             "lineHeight": "{font.line-height.sm}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1649,7 +1649,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.f-2}",
+            "fontSize": "{font-size.f-2}",
             "lineHeight": "{font.line-height.sm}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1661,7 +1661,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.f-1}",
+            "fontSize": "{font-size.f-1}",
             "lineHeight": "{font.line-height.sm}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
@@ -1671,7 +1671,7 @@
           "value": {
             "fontFamily": "{font.family.sans}",
             "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.f-2}",
+            "fontSize": "{font-size.f-2}",
             "lineHeight": "{font.line-height.sm}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },

--- a/tokens.json
+++ b/tokens.json
@@ -1266,179 +1266,23 @@
       }
     },
     "body": {
-      "xl": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font.size.f1}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "xl-strong": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font.size.f1}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "lg": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font-size.f0}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "lg-strong": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font-size.f0}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "md": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font-size.f-1}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "md-strong": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font-size.f-1}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "sm": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font-size.f-2}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "sm-strong": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font-size.f-2}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "xs": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font-size.f-3}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "xs-strong": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font-size.f-3}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      }
-    },
-    "display": {
-      "lg": {
-        "value": {
-          "fontFamily": "{font.family.brand}",
-          "fontWeight": "{font.weight.bold}",
-          "fontSize": "{font.size.bp-lg.f6}",
-          "lineHeight": "{font.line-height.md}",
-          "letterSpacing": "{font.letter-spacing.tight}"
-        },
-        "type": "typography"
-      },
-      "md": {
-        "value": {
-          "fontFamily": "{font.family.brand}",
-          "fontWeight": "{font.weight.bold}",
-          "fontSize": "{font.size.bp-lg.f5}",
-          "lineHeight": "{font.line-height.md}",
-          "letterSpacing": "{font.letter-spacing.tight}"
-        },
-        "type": "typography"
-      }
-    },
-    "caption": {
-      "md": {
-        "value": {
-          "fontFamily": "{font.family.mono}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font.size.bp-xl.f-2}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      },
-      "sm": {
-        "value": {
-          "fontFamily": "{font.family.mono}",
-          "fontWeight": "{font.weight.regular}",
-          "fontSize": "{font.size.bp-xl.f-3}",
-          "lineHeight": "{font.line-height.lg}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
-        },
-        "type": "typography"
-      }
-    },
-    "heading": {
-      "inter": {
-        "xxl": {
-          "value": {
-            "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f3}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.spacious}"
-          },
-          "type": "typography"
-        },
+      "regular": {
         "xl": {
           "value": {
             "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f2}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.spacious}"
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font.size.f1}",
+            "lineHeight": "{font.line-height.lg}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
         "lg": {
           "value": {
             "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f1}",
-            "lineHeight": "{font.line-height.md}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font-size.f0}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
@@ -1446,9 +1290,9 @@
         "md": {
           "value": {
             "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f0}",
-            "lineHeight": "{font.line-height.md}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font-size.f-1}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
@@ -1456,9 +1300,9 @@
         "sm": {
           "value": {
             "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f-1}",
-            "lineHeight": "{font.line-height.md}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font-size.f-2}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
@@ -1466,157 +1310,373 @@
         "xs": {
           "value": {
             "fontFamily": "{font.family.sans}",
-            "fontWeight": "{font.weight.semibold}",
-            "fontSize": "{font.size.bp-lg.f-2}",
-            "lineHeight": "{font.line-height.md}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font-size.f-3}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         }
       },
-      "wellcome": {
-        "xxl": {
-          "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f3}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.comfortable}"
-          },
-          "type": "typography"
-        },
+      "strong": {
         "xl": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f2}",
-            "lineHeight": "{font.line-height.md}",
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font.size.f1}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
         "lg": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f1}",
-            "lineHeight": "{font.line-height.md}",
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font-size.f0}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
         "md": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f0}",
-            "lineHeight": "{font.line-height.md}",
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font-size.f-1}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
         "sm": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f-1}",
-            "lineHeight": "{font.line-height.md}",
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font-size.f-2}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
         "xs": {
           "value": {
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font-size.f-3}",
+            "lineHeight": "{font.line-height.lg}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
+        }
+      }
+    },
+    "display": {
+      "strong": {
+        "lg": {
+          "value": {
             "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.regular}",
-            "fontSize": "{font.size.bp-lg.f-2}",
+            "fontWeight": "{font.weight.bold}",
+            "fontSize": "{font.size.f6}",
             "lineHeight": "{font.line-height.md}",
+            "letterSpacing": "{font.letter-spacing.tight}"
+          },
+          "type": "typography"
+        },
+        "md": {
+          "value": {
+            "fontFamily": "{font.family.brand}",
+            "fontWeight": "{font.weight.bold}",
+            "fontSize": "{font-size.f5}",
+            "lineHeight": "{font.line-height.md}",
+            "letterSpacing": "{font.letter-spacing.tight}"
+          },
+          "type": "typography"
+        }
+      }
+    },
+    "caption": {
+      "regular": {
+        "md": {
+          "value": {
+            "fontFamily": "{font.family.mono}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font-size.f-2}",
+            "lineHeight": "{font.line-height.lg}",
             "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
-        "xxl-strong": {
+        "sm": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f3}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+            "fontFamily": "{font.family.mono}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font.size.f-3}",
+            "lineHeight": "{font.line-height.lg}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
+        }
+      },
+      "strong": {
+        "md": {
+          "value": {
+            "fontFamily": "{font.family.mono}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font-size.f-2}",
+            "lineHeight": "{font.line-height.lg}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
         },
-        "xl-strong": {
+        "sm": {
           "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f2}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+            "fontFamily": "{font.family.mono}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font.size.f-3}",
+            "lineHeight": "{font.line-height.lg}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
           },
           "type": "typography"
+        }
+      }
+    },
+    "heading": {
+      "sans": {
+        "strong": {
+          "xxl": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f3}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.spacious}"
+            },
+            "type": "typography"
+          },
+          "xl": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.spacious}"
+            },
+            "type": "typography"
+          },
+          "lg": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "md": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f0}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "sm": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f-1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "xs": {
+            "value": {
+              "fontFamily": "{font.family.sans}",
+              "fontWeight": "{font.weight.semibold}",
+              "fontSize": "{font.size.f-2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          }
+        }
+      },
+      "brand": {
+        "regular": {
+          "xxl": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f3}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "xl": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "lg": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "md": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f0}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "sm": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f-1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          },
+          "xs": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.regular}",
+              "fontSize": "{font.size.f-2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.comfortable}"
+            },
+            "type": "typography"
+          }
         },
-        "lg-strong": {
-          "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f1}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+        "strong": {
+          "xxl": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f3}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
           },
-          "type": "typography"
-        },
-        "md-strong": {
-          "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f0}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+          "xl": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
           },
-          "type": "typography"
-        },
-        "sm-strong": {
-          "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f-1}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+          "lg": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
           },
-          "type": "typography"
-        },
-        "xs-strong": {
-          "value": {
-            "fontFamily": "{font.family.brand}",
-            "fontWeight": "{font.weight.bold}",
-            "fontSize": "{font.size.bp-lg.f-2}",
-            "lineHeight": "{font.line-height.md}",
-            "letterSpacing": "{font.letter-spacing.tight}"
+          "md": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f0}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
           },
-          "type": "typography"
+          "sm": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f-1}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
+          },
+          "xs": {
+            "value": {
+              "fontFamily": "{font.family.brand}",
+              "fontWeight": "{font.weight.bold}",
+              "fontSize": "{font.size.f-2}",
+              "lineHeight": "{font.line-height.md}",
+              "letterSpacing": "{font.letter-spacing.tight}"
+            },
+            "type": "typography"
+          }
         }
       }
     },
     "label": {
-      "md": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font.size.bp-lg.f-1}",
-          "lineHeight": "{font.line-height.sm}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
+      "strong": {
+        "md": {
+          "value": {
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font.size.f-1}",
+            "lineHeight": "{font.line-height.sm}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
         },
-        "type": "typography"
+        "sm": {
+          "value": {
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.semibold}",
+            "fontSize": "{font.size.f-2}",
+            "lineHeight": "{font.line-height.sm}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
+        }
       },
-      "sm": {
-        "value": {
-          "fontFamily": "{font.family.sans}",
-          "fontWeight": "{font.weight.semibold}",
-          "fontSize": "{font.size.bp-lg.f-2}",
-          "lineHeight": "{font.line-height.sm}",
-          "letterSpacing": "{font.letter-spacing.comfortable}"
+      "regular": {
+        "md": {
+          "value": {
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font.size.f-1}",
+            "lineHeight": "{font.line-height.sm}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
         },
-        "type": "typography"
+        "sm": {
+          "value": {
+            "fontFamily": "{font.family.sans}",
+            "fontWeight": "{font.weight.regular}",
+            "fontSize": "{font.size.f-2}",
+            "lineHeight": "{font.line-height.sm}",
+            "letterSpacing": "{font.letter-spacing.comfortable}"
+          },
+          "type": "typography"
+        }
       }
     }
   },


### PR DESCRIPTION
- Renamed heading typography tokens for consistency- Wellcome > brand, Inter > sans
- Reordered composite typography to be grouped by weight 
- Updated font size errors 
- added missing weights for caption and labels 

@Fahim lets review together when you are back from leave to confirm the approach and changes this will have on our figma setup. 

Don't merge until this has both design and dev approval 🙏
